### PR TITLE
Remove "Elements in Attributes" from API description clarity

### DIFF
--- a/text/0000-clarity-api-description.md
+++ b/text/0000-clarity-api-description.md
@@ -8,65 +8,70 @@ Provide clarity and additional elements/properites in API Description namespace.
 
 # Motivation
 
-This will make it easier to understand for new users and cover more areas for existing API Description formats.
+The purpose of this document is to make it easier for newcomers to understand the format and build tools around it.
 
 # Detailed design
 
-I have spent a lot of time thinking about this namespace, and I believe I’m going to keep my suggestions for now mostly to making the namespace clearer to new users. I think we can handle adding state and affordances to this later to accommodate things like the concepts from Resource Blueprints.
-
-This contains mostly questions and thoughts. Would love your thoughts on what you'd like to see addressed in a PR.
-
 ## Combine Namespaces
 
-I think we should combine the API Description namespace with the resource namespace. Z is already good with this, but listing it here.
+We should combine the API Description namespace with the resource namespace.
+Right now they are separate and it would be clearer if they were not.
 
 ## Elements in Attributes
 
-This is mainly a point for discussion. Refract allows for including elements within the attributes section of an element. Even though it’s possible, would it be helpful to avoid this in such an important namespace? Reason being, this will be one of the first places people interact with Refract, and to use complex features may be too much.
+Refract allows for including elements within the attributes section of an element.
+Even though it’s possible, it may be helpful to avoid this in such an important namespace.
+Reason being, this will be one of the first places people interact with Refract, and to use complex features may be too much.
 
 ## HREF Variables
 
-I think we should call them “hrefVariables” everywhere instead of parameters in places. I think this will be more consistent and easier to understand for newcomers. This will make more sense in how we handle inheritance.
-
-Question: does it make sense to provide an “in” attribute that defines where in the URI template the variable may be found (e.g. path, query param, etc.)?
+We should call them “hrefVariables” everywhere instead of parameters in places (specifically transitions).
+I think this will be more consistent and easier to understand for newcomers.
+This will make more sense in how we handle inheritance as well, because parameters inheriting from hrefVariables does not seem optimal.
 
 ## Defining Classes
 
-Swagger provides a way to define tags that can be applied to resources throughout the document. Refract has the “class” attribute that we can use the same way, we only need a way to define a class name and provide the description for it. Of course, this won’t carry over to API Blueprint, but that’s OK.
+Swagger provides a way to define tags that can be applied to resources throughout the document.
+Refract has the “class” attribute that we can use the same way, we only need a way to define a class name and provide the description for it.
+Of course, this won’t carry over to API Blueprint, but that’s OK.
 
 ## Clarify Inheritance
 
-We need to clarify how inheritance works with:
+We need to clarify how inheritance works by defining the behavior for:
 
 * HREF Variables and HREF values throughout the document
 * Content types in payloads
 * Methods in transitions
 * Resources with schemas (though not in the spec) should be inherited by transitions
 
-I don’t so much mind the inheritance rules, as we can handle this kind of inheritance with Minim by traversing the tree up and down for the correct HREF.
-
 ## Transitions at Root
 
-We should be able to define transitions on the root of the document and not require they are nested within a resource. This type of transition, though, should have a URL and a method.
-
-## Transition Attributes
-
-I think it would be helpful to call this something other than attributes, as this will not be obvious to most people. Additionally, it means you have “element.attributes.attributes”, which is not a big deal, but something I think we can avoid. Not sure what to call it.
-
-This seems to me like a data structure for the transition.
+We should be able to define transitions on the root of the document and not require they are nested within a resource.
+This type of transition, though, should have a URL and a method.
 
 ## Subclass Asset
 
-I think it would be clearer if we subclass the Asset Element and added one called “messageShema” and another called “messageBody.” I think this will make reading a API Description make more sense than seeing Asset alone with classes.
-
-## Category Element
-
-I still have trouble understanding what “category” means here, but that may just be me. Is there a better name? Is this from the philosophical world? Maybe something like “section” or from the HTML world “div”?
+We should subclass the Asset Element and add one called “messageShema” and another called “messageBody.”
+This will make reading a API Description make more sense than seeing Asset alone with classes.
 
 ## Provided Media Types
 
-Swagger supports a section that defines what formats the server will respond with. This should be added (already discussed with Z).
+We should add a section that defines what media types the server will respond with.
 
 ## Add Schema to Resource
 
-Should resources be able to have their own schema (currently Asset with `messageBodySchema` as class).
+A resource should be able to have its own schema, whereas now it cannot.
+
+# Unresolved questions
+
+## Category Element
+
+What is a "category"?
+Does this word make sense used here?
+Maybe something like “section” or from the HTML world “div”?
+
+## Transition Attributes
+
+I think it would be helpful to call this something other than attributes, as this will not be obvious to most people.
+We have parameters, variables, and attributes throughout the document, which seems confusing.
+What should this be called?

--- a/text/0000-clarity-api-description.md
+++ b/text/0000-clarity-api-description.md
@@ -1,0 +1,68 @@
+- Start Date: 2015-06-18
+- RFC PR: (leave this empty)
+- Refract Issue: (leave this empty)
+
+# Summary
+
+Provide clarity and additional elements/properites in API Description namespace.
+
+# Motivation
+
+This will make it easier to understand for new users and cover more areas for existing API Description formats.
+
+# Detailed design
+
+I have spent a lot of time thinking about this namespace, and I believe I’m going to keep my suggestions for now mostly to making the namespace clearer to new users. I think we can handle adding state and affordances to this later to accommodate things like the concepts from Resource Blueprints.
+
+This contains mostly questions and thoughts. Would love your thoughts on what you'd like to see addressed in a PR.
+
+## Combine Namespaces
+
+I think we should combine the API Description namespace with the resource namespace. Z is already good with this, but listing it here.
+
+## Elements in Attributes
+
+This is mainly a point for discussion. Refract allows for including elements within the attributes section of an element. Even though it’s possible, would it be helpful to avoid this in such an important namespace? Reason being, this will be one of the first places people interact with Refract, and to use complex features may be too much.
+
+## HREF Variables
+
+I think we should call them “hrefVariables” everywhere instead of parameters in places. I think this will be more consistent and easier to understand for newcomers. This will make more sense in how we handle inheritance.
+
+Question: does it make sense to provide an “in” attribute that defines where in the URI template the variable may be found (e.g. path, query param, etc.)?
+
+## Defining Classes
+
+Swagger provides a way to define tags that can be applied to resources throughout the document. Refract has the “class” attribute that we can use the same way, we only need a way to define a class name and provide the description for it. Of course, this won’t carry over to API Blueprint, but that’s OK.
+
+## Clarify Inheritance
+
+We need to clarify how inheritance works with:
+
+* HREF Variables and HREF values throughout the document
+* Content types in payloads
+* Methods in transitions
+* Resources with schemas (though not in the spec) should be inherited by transitions
+
+I don’t so much mind the inheritance rules, as we can handle this kind of inheritance with Minim by traversing the tree up and down for the correct HREF.
+
+## Transitions at Root
+
+We should be able to define transitions on the root of the document and not require they are nested within a resource. This type of transition, though, should have a URL and a method.
+
+## Transition Attributes
+
+I think it would be helpful to call this something other than attributes, as this will not be obvious to most people. Additionally, it means you have “element.attributes.attributes”, which is not a big deal, but something I think we can avoid. Not sure what to call it.
+
+This seems to me like a data structure for the transition.
+
+## Subclass Asset
+
+I think it would be clearer if we subclass the Asset Element and added one called “messageShema” and another called “messageBody.” I think this will make reading a API Description make more sense than seeing Asset alone with classes.
+
+## Category Element
+
+I still have trouble understanding what “category” means here, but that may just be me. Is there a better name? Is this from the philosophical world? Maybe something like “section” or from the HTML world “div”?
+
+## Provided Media Types
+
+Swagger supports a section that defines what formats the server will respond with. This should be added (already discussed with Z).

--- a/text/0000-clarity-api-description.md
+++ b/text/0000-clarity-api-description.md
@@ -66,3 +66,7 @@ I still have trouble understanding what “category” means here, but that may 
 ## Provided Media Types
 
 Swagger supports a section that defines what formats the server will respond with. This should be added (already discussed with Z).
+
+## Add Schema to Resource
+
+Should resources be able to have their own schema (currently Asset with `messageBodySchema` as class).

--- a/text/0000-clarity-api-description.md
+++ b/text/0000-clarity-api-description.md
@@ -17,12 +17,6 @@ The purpose of this document is to make it easier for newcomers to understand th
 We should combine the API Description namespace with the resource namespace.
 Right now they are separate and it would be clearer if they were not.
 
-## Elements in Attributes
-
-Refract allows for including elements within the attributes section of an element.
-Even though it’s possible, it may be helpful to avoid this in such an important namespace.
-Reason being, this will be one of the first places people interact with Refract, and to use complex features may be too much.
-
 ## HREF Variables
 
 We should call them “hrefVariables” everywhere instead of parameters in places (specifically transitions).


### PR DESCRIPTION
This is a PR into #1, to remove "Elements in Attributes" from API description clarity.

Seems like there is an agreement we shouldn't do this (https://github.com/refractproject/rfcs/pull/1#discussion_r32821459).

@smizell please merge
