### PR TITLE
Remove various items from Clarity API Description RFC

### DIFF
--- a/text/0000-clarity-api-description.md
+++ b/text/0000-clarity-api-description.md
@@ -41,10 +41,6 @@ This type of transition, though, should have a URL and a method.
 
 We should add a section that defines what media types the server will respond with.
 
-## Add Schema to Resource
-
-A resource should be able to have its own schema, whereas now it cannot.
-
 # Unresolved questions
 
 ## Category Element

--- a/text/0000-clarity-api-description.md
+++ b/text/0000-clarity-api-description.md
@@ -43,12 +43,6 @@ We should add a section that defines what media types the server will respond wi
 
 # Unresolved questions
 
-## Category Element
-
-What is a "category"?
-Does this word make sense used here?
-Maybe something like “section” or from the HTML world “div”?
-
 ## Transition Attributes
 
 I think it would be helpful to call this something other than attributes, as this will not be obvious to most people.

--- a/text/0000-clarity-api-description.md
+++ b/text/0000-clarity-api-description.md
@@ -23,12 +23,6 @@ We should call them “hrefVariables” everywhere instead of parameters in plac
 I think this will be more consistent and easier to understand for newcomers.
 This will make more sense in how we handle inheritance as well, because parameters inheriting from hrefVariables does not seem optimal.
 
-## Defining Classes
-
-Swagger provides a way to define tags that can be applied to resources throughout the document.
-Refract has the “class” attribute that we can use the same way, we only need a way to define a class name and provide the description for it.
-Of course, this won’t carry over to API Blueprint, but that’s OK.
-
 ## Clarify Inheritance
 
 We need to clarify how inheritance works by defining the behavior for:


### PR DESCRIPTION
This removes:
- Defining Classes
- Add Schema to Resource
- Category Element (proposed rename)

I believe this is what we're all agreeing to do, de-scope these items from the proposal and introduce later via separate RFCs in a backwards compatible manner.
