### PR TITLE
RFC to Introduce Hyperlinking

### DIFF
--- a/text/0000-add-hyperlinks.md
+++ b/text/0000-add-hyperlinks.md
@@ -1,0 +1,30 @@
+- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- RFC PR: (leave this empty)
+- Refract Issue: (leave this empty)
+
+# Summary
+
+One paragraph explanation of the feature.
+
+# Motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+# Detailed design
+
+This is the bulk of the RFC. Explain the design in enough detail for somebody familiar
+with the framework to understand, and for somebody familiar with the implementation to implement.
+This should get into specifics and corner-cases, and include examples of how the feature is used.
+Any new terminology should be defined here.
+
+# Drawbacks
+
+Why should we *not* do this?
+
+# Alternatives
+
+What other designs have been considered? What is the impact of not doing this?
+
+# Unresolved questions
+
+What parts of the design are still TBD?


### PR DESCRIPTION
This is an RFC for adding hyperlinking to the base Refract specification.

cc @zdne 
