### PR TITLE
RFC for Adding Hyperlinking

### DIFF
--- a/text/0000-add-hyperlinks.md
+++ b/text/0000-add-hyperlinks.md
@@ -12,14 +12,12 @@ As we encounter more real-world Refract situations, we are noticing that we seem
 
 # Design
 
-This proposal is for adding a `links` property to the `meta` object in Refract elements.
+This proposal is for adding a Link Element to the base spec.
 
-- `links` (array)
-    - (object)
-        - `rel` - Link relation of the link
-        - `href` - Resolvable URL for the link
-
-The `rel` property SHOULD conform to [RFC 5988](https://tools.ietf.org/html/rfc5988). Link relations should be as registered or extension link relations, and MAY be defined in profile documents.
+- `element`: link (string, fixed)
+- `attributes`
+    - `relation` (string) - Link relation type as specified in [RFC 5988][].
+    - `href` (string) - The URI for the given link
 
 ## Use Cases
 
@@ -39,12 +37,18 @@ This example shows a `foo` element with two links. The presence of the `edit` li
   meta: {
     links: [
       {
-        rel: 'edit',
-        href: '/bar/1'
+        element: 'link',
+        attributes: {
+          relation: 'edit',
+          href: '/bar/1'
+        }
       },
       {
-        rel: 'self',
-        href: '/bar/1'
+        element: 'link',
+        attributes: {
+          relation: 'self',
+          href: '/bar/1'
+        }
       }
     ]
   }
@@ -53,21 +57,15 @@ This example shows a `foo` element with two links. The presence of the `edit` li
 
 ## Embeddeding Links
 
-In some situations, it may be advantageous to embed the resources themselves that would be found when the link was resolved. This current proposal is not addressing this yet, though it may be something we should look into in this RFC. This would happen if the design would go better together.
+While not addressed in this PR, embedding links may be possible by including the [Asset Element](https://github.com/refractproject/refract-spec/blob/master/namespaces/api-description-namespace.md#asset-element) in the base specification and making it available as content for this Link Element.
 
 ## Additional Benefits
 
-Additionally, if hyperlinks are used in this way, we may be able to remove the concept of namespaces from the base Refract specification. The namespace properties allowed for programmatically including additional elements, but so far no library is using or has implemented this functionality. Since we've been using content types for extending Refract documents, we could use the `profile` link relation to define additional functionality and link relations.
+Additionally, if hyperlinks are used in this way, we may be able to remove the concept of namespaces from the base Refract specification. This change is out of scope of this RFC, but mentioning so we keep it in mind.
 
-If we go this route, we can make the following changes to the base Refract specification.
+## Transition in the API Description Namespace
 
-- Remove `prefix` and `namespace` from the `meta` object
-- Simplify the `ref` property in the `meta` object to just be a URI string
-- Remove the need for the current [Link](https://github.com/refractproject/refract-spec/blob/master/refract-spec.md#link-enum)
-- Simplify the [Ref Element](https://github.com/refractproject/refract-spec/blob/master/refract-spec.md#ref-element-element) to just have a URI as its content, which is just a string
-- Remove the [Namespacing](https://github.com/refractproject/refract-spec/blob/master/refract-spec.md#ref-element-element) section
-
-This is quite the simplification of the specification, both in length and complexity.
+If we do this, the [Transition element](https://github.com/refractproject/refract-spec/blob/master/namespaces/api-description-namespace.md#transition-element) in the API Description will inherit from this element.
 
 # Drawbacks
 
@@ -80,5 +78,3 @@ The alternative would be creating more namespaces, media types, and namespace-sp
 # Unresolved questions
 
 * Whether to do this or continue creating namespaces
-* Whether to remove namespacing from the current spec
-* Whether to include the ability to embed links

--- a/text/0000-add-hyperlinks.md
+++ b/text/0000-add-hyperlinks.md
@@ -1,0 +1,30 @@
+- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- RFC PR: (leave this empty)
+- Refract Issue: (leave this empty)
+
+# Summary
+
+One paragraph explanation of the feature.
+
+# Motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+# Detailed design
+
+This is the bulk of the RFC. Explain the design in enough detail for somebody familiar
+with the framework to understand, and for somebody familiar with the implementation to implement.
+This should get into specifics and corner-cases, and include examples of how the feature is used.
+Any new terminology should be defined here.
+
+# Drawbacks
+
+Why should we *not* do this?
+
+# Alternatives
+
+What other designs have been considered? What is the impact of not doing this?
+
+# Unresolved questions
+
+What parts of the design are still TBD?

--- a/text/0000-add-hyperlinks.md
+++ b/text/0000-add-hyperlinks.md
@@ -19,7 +19,7 @@ This proposal is for adding a `links` property to the `meta` object in Refract e
         - `rel` - Link relation of the link
         - `href` - Resolvable URL for the link
 
-The `rel` property MAY be any defined [link relation](http://www.iana.org/assignments/link-relations/link-relations.xhtml), a resolvable URL to documentation on the link relation, or defined in a `profile` link.
+The `rel` property SHOULD conform to [RFC 5988](https://tools.ietf.org/html/rfc5988). Link relations should be as registered or extension link relations, and MAY be defined in profile documents.
 
 ## Use Cases
 
@@ -57,7 +57,17 @@ In some situations, it may be advantageous to embed the resources themselves tha
 
 ## Additional Benefits
 
-Additionally, if hyperlinks are used in this way, we may be able to remove the concept of namespaces from the base Refract specification. The namespace options allowed for including additional elements, but so far no library is using or has implemented this functionality. Since we've been using content types for extending Refract documents, we could use the `profile` link relation to define additional functionality.
+Additionally, if hyperlinks are used in this way, we may be able to remove the concept of namespaces from the base Refract specification. The namespace properties allowed for programmatically including additional elements, but so far no library is using or has implemented this functionality. Since we've been using content types for extending Refract documents, we could use the `profile` link relation to define additional functionality and link relations.
+
+If we go this route, we can make the following changes to the base Refract specification.
+
+- Remove `prefix` and `namespace` from the `meta` object
+- Simplify the `ref` property in the `meta` object to just be a URI string
+- Remove the need for the current [Link](https://github.com/refractproject/refract-spec/blob/master/refract-spec.md#link-enum)
+- Simplify the [Ref Element](https://github.com/refractproject/refract-spec/blob/master/refract-spec.md#ref-element-element) to just have a URI as its content, which is just a string
+- Remove the [Namespacing](https://github.com/refractproject/refract-spec/blob/master/refract-spec.md#ref-element-element) section
+
+This is quite the simplification of the specification, both in length and complexity.
 
 # Drawbacks
 

--- a/text/0000-add-hyperlinks.md
+++ b/text/0000-add-hyperlinks.md
@@ -1,30 +1,73 @@
-- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- Start Date: 2015-11-24
 - RFC PR: (leave this empty)
 - Refract Issue: (leave this empty)
 
 # Summary
 
-One paragraph explanation of the feature.
+The RFC outlines adding hyperlinking into the base Refract specification.
 
 # Motivation
 
-Why are we doing this? What use cases does it support? What is the expected outcome?
+As we encounter more real-world Refract situations, we are noticing that we seem to need namespaces for domain-specific uses. To provide a general way to extend Refract documents, this document proposes using hyperlinking.
 
-# Detailed design
+# Design
 
-This is the bulk of the RFC. Explain the design in enough detail for somebody familiar
-with the framework to understand, and for somebody familiar with the implementation to implement.
-This should get into specifics and corner-cases, and include examples of how the feature is used.
-Any new terminology should be defined here.
+This proposal is for adding a `links` property to the `meta` object in Refract elements.
+
+- `links` (array)
+    - (object)
+        - `rel` - Link relation of the link
+        - `href` - Resolvable URL for the link
+
+The `rel` property MAY be any defined [link relation](http://www.iana.org/assignments/link-relations/link-relations.xhtml), a resolvable URL to documentation on the link relation, or defined in a `profile` link.
+
+## Use Cases
+
+As mentioned, it is becoming common to need to add domain-specific information into documents. Providing hyperlinks allows to convey this kind of information without adding additional namespace specifications. The downside of additional namespaces is that they require new media types and new libraries. Baking in hyperlinks can provide an avenue that does not require new namespaces.
+
+This shows up when trying to convey state of an element or resource. For instance, the presence of an `edit` link relation in an element tells the client not only how to edit the element, but also that it can edit it. If the link is not there, the client knows it cannot edit that given element or resource.
+
+Additionally, it is common to provide properties that couple the format with certain state and functionality. In the above example, a designer may include `canEdit: true` as a property in an element's attributes. To accomplish this, the designer needs to document this somewhere, but that documentation is now out of band.
+
+## Example
+
+This example shows a `foo` element with two links. The presence of the `edit` link tells the client the user can edit the given element or document, and the `self` link provides a link to the actual resource.
+
+```js
+{
+  element: 'foo',
+  meta: {
+    links: [
+      {
+        rel: 'edit',
+        href: '/bar/1'
+      },
+      {
+        rel: 'self',
+        href: '/bar/1'
+      }
+    ]
+  }
+}
+```
+
+## Embeddeding Links
+
+In some situations, it may be advantageous to embed the resources themselves that would be found when the link was resolved. This current proposal is not addressing this yet, though it may be something we should look into in this RFC. This would happen if the design would go better together.
+
+## Additional Benefits
+
+Additionally, if hyperlinks are used in this way, we may be able to remove the concept of namespaces from the base Refract specification. The namespace options allowed for including additional elements, but so far no library is using or has implemented this functionality. Since we've been using content types for extending Refract documents, we could use the `profile` link relation to define additional functionality.
 
 # Drawbacks
 
-Why should we *not* do this?
+While this direction is very flexible and usable, it may be seen as more complex than simple adding domain-specific namespaces.
 
 # Alternatives
 
-What other designs have been considered? What is the impact of not doing this?
+The alternative would be creating more namespaces, media types, and namespace-specific libraries.
 
 # Unresolved questions
 
-What parts of the design are still TBD?
+* Whether to do this or continue creating namespaces
+* Whether to include the ability to embed links

--- a/text/0000-add-hyperlinks.md
+++ b/text/0000-add-hyperlinks.md
@@ -80,4 +80,5 @@ The alternative would be creating more namespaces, media types, and namespace-sp
 # Unresolved questions
 
 * Whether to do this or continue creating namespaces
+* Whether to remove namespacing from the current spec
 * Whether to include the ability to embed links


### PR DESCRIPTION
This adds the RFC for adding hyperlinking into the base Refract specification.
