### PR TITLE
Element Pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ consistent and controlled path for new features to enter the framework.
 - [0005 Embedded Refract](text/0005-embedded-refract.md)
 - [0011 Remove Namespacing in Base Specification](text/0011-remove-namespacing.md)
 - [0012 Reserve Element](text/0012-reserve-element.md)
+- [0013 Element Pointer](text/0013-element-pointer.md)
 
 ## Completed RFC List
 

--- a/text/0013-element-pointer.md
+++ b/text/0013-element-pointer.md
@@ -1,5 +1,5 @@
 - Start Date: 2017-03-28
-- RFC PR: (leave this empty)
+- RFC PR: https://github.com/refractproject/rfcs/pull/38
 - Refract Issue: (leave this empty)
 
 # Element Pointer

--- a/text/XXXX-element-pointer.md
+++ b/text/XXXX-element-pointer.md
@@ -1,0 +1,33 @@
+- Start Date: 2017-03-28
+- RFC PR: (leave this empty)
+- Refract Issue: (leave this empty)
+
+# Element Pointer
+
+## Summary
+
+Element Pointer is currently a special case and the only type that does not
+extend from an element which means it has special rules when it comes to
+serialisation and de-serialisations.
+
+## Motivation
+
+To aid simplicity and to remove complexity of Refract serialisation, we should
+move Element Pointer to be an element itself. This would be more consistent
+with other elements such as the Link element.
+
+## Detailed design
+
+The Element Pointer should become an Element Pointer element which can be
+described as follows:
+
+### Element Pointer
+
++ element: elementPointer (fixed)
++ attributes
+    + path (enum) - Path of the referenced element to transclude instad of element itself
+        + element (default)
+        + meta
+        + attributes
+        + content
++ content (string) - A URL to an ID of an element in the current document


### PR DESCRIPTION
Element Pointer is currently a special case and the only type that does not extend from an element which means it has special rules when it comes to serialisation and de-serialisations. These have been brought up in the discussion at https://github.com/refractproject/rfcs/pull/36#discussion_r108148908 and while we are at it, I think it makes sense for the element pointer to become an element.